### PR TITLE
fix link version per twitter comment

### DIFF
--- a/.github/workflows/tweet-preprint.yaml
+++ b/.github/workflows/tweet-preprint.yaml
@@ -1,7 +1,7 @@
 name: Tweet preprint
 
 on:
-  # daily at 8:00pm UTC
+  # run daily
   schedule:
     - cron: "0 20 * * *"
 

--- a/bot.js
+++ b/bot.js
@@ -100,9 +100,6 @@ function makeStatuses({ preprint = null, comment = null }) {
       )
       .join(" ") + " et al";
 
-  // link to preprint on bio/medrxiv
-  const url = preprint.biorxiv_url || preprint.medrxiv_url;
-
   // capitalize category
   const category =
     preprint.category[0].toUpperCase() + preprint.category.substr(1);
@@ -116,6 +113,9 @@ function makeStatuses({ preprint = null, comment = null }) {
 
     // comment raw text
     const message = comment.raw_message;
+
+    // link to page where comment was made
+    const url = comment.link;
 
     // status template for tweeting comment
     const status = [
@@ -139,6 +139,9 @@ function makeStatuses({ preprint = null, comment = null }) {
   } else {
     // truncate title
     const title = preprint.title;
+
+    // link to preprint page on bio/medrxiv
+    const url = preprint.biorxiv_url || preprint.medrxiv_url;
 
     // status template for tweeting preprint
     const status = [

--- a/disqus.js
+++ b/disqus.js
@@ -45,7 +45,7 @@ async function getComments() {
   }
 }
 
-// get details about thread, like page link
+// get link of page comment is on
 async function getLink(thread) {
   // set search params
   const params = new URLSearchParams();

--- a/disqus.js
+++ b/disqus.js
@@ -30,8 +30,10 @@ async function getComments() {
     comments = (
       await Promise.all(
         comments.map(async (comment) => {
-          const doi = await getDoi(comment.thread);
+          const link = await getLink(comment.thread);
+          const doi = getDoi(link);
           const preprint = await getPreprint(doi);
+          comment.link = link;
           if (comment && preprint) return { comment, preprint };
         })
       )
@@ -43,26 +45,22 @@ async function getComments() {
   }
 }
 
-// get preprint doi from comment thread
-async function getDoi(thread) {
+// get details about thread, like page link
+async function getLink(thread) {
   // set search params
   const params = new URLSearchParams();
   params.set("api_key", disqus_api_key);
   params.set("thread", thread);
 
-  // get link of post
+  // get link of page
   const response =
     (await (await fetch(detailsApi + "?" + params.toString())).json())
       .response || [];
-  const link = response.link;
-
-  // get doi from url
-  return cleanDoi(link);
+  return response.link;
 }
 
 // remove everything before first number, eg "doi:"
 // remove version at end, eg "v4"
-const cleanDoi = (query) =>
-  query.replace(/^\D*/g, "").replace(/v\d+$/g, "").trim();
+const getDoi = (link) => link.replace(/^\D*/g, "").replace(/v\d+$/g, "").trim();
 
 module.exports = { getComments, getDoi };


### PR DESCRIPTION
Per @michaelmhoffman:

> It's nice but this example links to the latest version of that preprint while the comment are on previous versions. A little confusing.

- for link to preprint, use page link returned from Disqus api when bot is running in comment mode, rather than link returned from Rxivist