### PR TITLE
fix error when comment returns biorxiv link without doi

### DIFF
--- a/.github/workflows/tweet-comment.yaml
+++ b/.github/workflows/tweet-comment.yaml
@@ -6,7 +6,7 @@ on:
     - cron: "0 12,14,16,18,20,22,0 * * *"
 
 jobs:
-  run-bot:
+  tweet-comment:
     runs-on: ubuntu-latest
     environment: preprint-bot
     env:

--- a/.github/workflows/tweet-preprint.yaml
+++ b/.github/workflows/tweet-preprint.yaml
@@ -6,7 +6,7 @@ on:
     - cron: "0 20 * * *"
 
 jobs:
-  run-bot:
+  tweet-preprint:
     runs-on: ubuntu-latest
     environment: preprint-bot
     env:

--- a/bot.js
+++ b/bot.js
@@ -26,7 +26,7 @@ async function runBot(type = "preprint") {
   console.log("");
   info("Selecting preprints");
   let selected = await selectPreprint(preprints, log);
-  if (!selected?.doi) throw new Error("Couldn't select preprint");
+  if (!selected?.preprint?.doi) throw new Error("Couldn't select preprint");
   success(`Selected ${selected.preprint.doi}`);
 
   // make tweet status messages
@@ -60,7 +60,7 @@ async function selectPreprint(preprints, log = []) {
 
   // go through preprints until we find one acceptable
   for (const preprint of preprints) {
-    console.log(preprint.doi);
+    console.log(preprint?.preprint?.doi);
 
     // check that preprint isn't a repeat tweet
     if (isRepeat(preprint, log)) {

--- a/bot.js
+++ b/bot.js
@@ -26,8 +26,7 @@ async function runBot(type = "preprint") {
   console.log("");
   info("Selecting preprints");
   let selected = await selectPreprint(preprints, log);
-  if (!selected) throw new Error("Couldn't select preprint");
-  console.log(selected);
+  if (!selected?.doi) throw new Error("Couldn't select preprint");
   success(`Selected ${selected.preprint.doi}`);
 
   // make tweet status messages
@@ -61,7 +60,7 @@ async function selectPreprint(preprints, log = []) {
 
   // go through preprints until we find one acceptable
   for (const preprint of preprints) {
-    console.log(preprint);
+    console.log(preprint.doi);
 
     // check that preprint isn't a repeat tweet
     if (isRepeat(preprint, log)) {

--- a/keys.js
+++ b/keys.js
@@ -23,9 +23,10 @@ const keys = {
 };
 
 // log keys
-for (const [key, value] of Object.entries(keys)) {
-  keys[key] = value.trim();
-  console.log(`${key}: ${value.trim() ? `"...${value.slice(-4)}"` : `""`}`);
+for (let [key, value] of Object.entries(keys)) {
+  value = value.trim();
+  keys[key] = value;
+  console.log(`${key}: ${value ? `"...${value.slice(-4)}"` : `""`}`);
 }
 
 module.exports = keys;

--- a/rxivist.js
+++ b/rxivist.js
@@ -17,6 +17,7 @@ async function getPreprints() {
 async function getPreprint(doi) {
   try {
     const response = await (await fetch(api + "/" + doi)).json();
+    if (response.error) throw new Error(response.error);
     return response;
   } catch (error) {
     return null;


### PR DESCRIPTION
- remove verbose logging (maybe will fix the random errors like [this one](https://github.com/greenelab/preprint-bot/runs/2755283036?check_suite_focus=true) where the process exits for apparently no reason)
- fix bug with comments that return biorxiv links with no dois in them. doesn't throw error anymore, just skips the comment. see #6 for more robust solution
- clean up key logging
- rename gh-actions job names